### PR TITLE
Add testthat suite for dev/aes-api-refactor API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,8 @@ Imports:
     VariantAnnotation,
     StructuralVariantAnnotation,
     rtracklayer
+Suggests:
+    testthat (>= 3.0.0)
 RoxygenNote: 7.3.2
 URL: https://github.com/andrewrlynch/THEfunc
 BugReports: https://github.com/andrewrlynch/THEfunc/issues

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(THEfunc)
+
+test_check("THEfunc")

--- a/tests/testthat/test-aes.R
+++ b/tests/testthat/test-aes.R
@@ -1,0 +1,58 @@
+test_that("aes() returns a SeqAes object", {
+  a <- aes(y = cell_type)
+  expect_s3_class(a, "SeqAes")
+})
+
+test_that("aes() deparsed bare symbols to character strings", {
+  a <- aes(y = cell_type, fill = mutation_count)
+  expect_equal(a[["y"]], "cell_type")
+  expect_equal(a[["fill"]], "mutation_count")
+})
+
+test_that("aes() with quoted strings are passed through", {
+  a <- aes(y = "cell_type")
+  # deparse("cell_type") -> '"cell_type"' with outer quotes -- check the actual
+  # raw string stored matches the deparsed form of the quoted literal
+  expect_equal(a[["y"]], '"cell_type"')
+})
+
+test_that("aes() normalises 'col' to 'color' and removes 'col'", {
+  a <- aes(col = my_col)
+  expect_equal(a[["color"]], "my_col")
+  expect_null(a[["col"]])
+})
+
+test_that("aes() normalises 'colour' to 'color' and removes 'colour'", {
+  a <- aes(colour = my_colour)
+  expect_equal(a[["color"]], "my_colour")
+  expect_null(a[["colour"]])
+})
+
+test_that("aes() 'color' takes precedence over 'col' when both supplied", {
+  # Only col/colour → color alias when 'color' is NOT already present
+  a <- aes(color = explicit_col, col = other_col)
+  # 'color' was explicit, so 'col' alias should not override it
+  expect_equal(a[["color"]], "explicit_col")
+})
+
+test_that("aes() NULL arguments are excluded from the mapping", {
+  a <- aes(y = cell_type, fill = NULL)
+  expect_equal(a[["y"]], "cell_type")
+  expect_null(a[["fill"]])
+})
+
+test_that("aes() with no arguments returns an empty SeqAes", {
+  a <- aes()
+  expect_s3_class(a, "SeqAes")
+  expect_equal(length(a), 0L)
+})
+
+test_that("aes() supports all documented aesthetic arguments", {
+  a <- aes(x = pos, y = group, fill = score, alpha = conf, size = weight, shape = type)
+  expect_equal(a[["x"]], "pos")
+  expect_equal(a[["y"]], "group")
+  expect_equal(a[["fill"]], "score")
+  expect_equal(a[["alpha"]], "conf")
+  expect_equal(a[["size"]], "weight")
+  expect_equal(a[["shape"]], "type")
+})

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -1,0 +1,119 @@
+# Helper: a minimal single-window GRanges for SeqPlot/SeqTrack setup
+.make_windows <- function() GenomicRanges::GRanges("chr1:1-248956422")
+
+# Helper: a small GRanges with a numeric score column
+.make_gr <- function() {
+  GenomicRanges::GRanges(
+    c("chr1:1000-2000", "chr1:3000-4000", "chr1:5000-6000"),
+    score = c(1.0, 2.0, 3.0)
+  )
+}
+
+
+# ── %|% operator ─────────────────────────────────────────────────────────────
+
+test_that("%|% adds a SeqTrack to an empty SeqPlot", {
+  plt <- SeqPlot(windows = .make_windows())
+  trk <- SeqTrack()
+  result <- plt %|% trk
+  expect_identical(result, plt)
+  expect_length(plt$tracks, 1L)
+})
+
+test_that("%|% adds multiple tracks in order", {
+  plt <- SeqPlot(windows = .make_windows())
+  plt %|% SeqTrack() %|% SeqTrack()
+  expect_length(plt$tracks, 2L)
+})
+
+test_that("%|% returns the SeqPlot invisibly (same object)", {
+  plt <- SeqPlot(windows = .make_windows())
+  result <- plt %|% SeqTrack()
+  expect_identical(result, plt)
+})
+
+test_that("%|% errors when right-hand side is not a SeqTrack", {
+  plt <- SeqPlot(windows = .make_windows())
+  expect_error(plt %|% "not a track")
+  expect_error(plt %|% 42)
+  expect_error(plt %|% list())
+})
+
+
+# ── %+% on SeqPlot ───────────────────────────────────────────────────────────
+
+test_that("%+% adds a SeqElement to the last track in a SeqPlot", {
+  plt <- SeqPlot(windows = .make_windows()) %|% SeqTrack()
+  pt  <- SeqPoint(.make_gr(), yCol = "score")
+  result <- plt %+% pt
+  expect_identical(result, plt)
+  expect_length(plt$tracks[[1]]$elements, 1L)
+})
+
+test_that("%+% targets only the last track, not earlier ones", {
+  plt <- SeqPlot(windows = .make_windows()) %|% SeqTrack() %|% SeqTrack()
+  pt  <- SeqPoint(.make_gr(), yCol = "score")
+  plt %+% pt
+  expect_length(plt$tracks[[1]]$elements, 0L)
+  expect_length(plt$tracks[[2]]$elements, 1L)
+})
+
+test_that("%+% errors when SeqPlot has no tracks", {
+  plt <- SeqPlot(windows = .make_windows())
+  pt  <- SeqPoint(.make_gr(), yCol = "score")
+  expect_error(plt %+% pt)
+})
+
+test_that("%+% errors when right-hand side is not a SeqElement", {
+  plt <- SeqPlot(windows = .make_windows()) %|% SeqTrack()
+  expect_error(plt %+% "not an element")
+  expect_error(plt %+% 42)
+})
+
+
+# ── %+% on SeqTrack ──────────────────────────────────────────────────────────
+
+test_that("%+% adds a SeqElement directly to a SeqTrack", {
+  trk <- SeqTrack()
+  pt  <- SeqPoint(.make_gr(), yCol = "score")
+  result <- trk %+% pt
+  expect_identical(result, trk)
+  expect_length(trk$elements, 1L)
+})
+
+test_that("%+% can add multiple elements to a SeqTrack", {
+  trk <- SeqTrack()
+  gr  <- .make_gr()
+  trk %+% SeqPoint(gr, yCol = "score") %+% SeqLine(gr, yCol = "score")
+  expect_length(trk$elements, 2L)
+})
+
+test_that("%+% errors on SeqTrack when right-hand side is not a SeqElement", {
+  trk <- SeqTrack()
+  expect_error(trk %+% "bad")
+})
+
+
+# ── Chained operator pipeline ─────────────────────────────────────────────────
+
+test_that("full pipeline SeqPlot() %|% SeqTrack() %+% SeqPoint() builds correctly", {
+  gr  <- .make_gr()
+  plt <- SeqPlot(windows = .make_windows()) %|%
+    SeqTrack() %+%
+    SeqPoint(gr, yCol = "score")
+
+  expect_length(plt$tracks, 1L)
+  expect_length(plt$tracks[[1]]$elements, 1L)
+  expect_true(inherits(plt$tracks[[1]]$elements[[1]], "SeqPoint"))
+})
+
+test_that("multi-track pipeline builds the expected structure", {
+  gr  <- .make_gr()
+  plt <- SeqPlot(windows = .make_windows()) %|%
+    SeqTrack() %+% SeqPoint(gr, yCol = "score") %|%
+    SeqTrack() %+% SeqLine(gr,  yCol = "score")
+
+  expect_length(plt$tracks, 2L)
+  expect_true(inherits(plt$tracks[[1]]$elements[[1]], "SeqPoint"))
+  expect_true(inherits(plt$tracks[[2]]$elements[[1]], "SeqLine"))
+})

--- a/tests/testthat/test-resolve-aes.R
+++ b/tests/testthat/test-resolve-aes.R
@@ -1,0 +1,164 @@
+# Tests for the internal .resolve_aes() function.
+# Access via THEfunc:::.resolve_aes() since it is not exported.
+
+.resolve <- THEfunc:::.resolve_aes
+
+
+# ── NULL / no-op cases ────────────────────────────────────────────────────────
+
+test_that(".resolve_aes() with NULL aes returns default color vector", {
+  df     <- data.frame(x = 1:4)
+  result <- .resolve(df, NULL, NULL, n = 4, default_color = "#ABCDEF")
+  expect_equal(result$color, rep("#ABCDEF", 4))
+})
+
+test_that(".resolve_aes() with NULL aes returns exactly n entries", {
+  df     <- data.frame(x = 1:7)
+  result <- .resolve(df, NULL, NULL, n = 7, default_color = "grey")
+  expect_length(result$color, 7L)
+})
+
+
+# ── Discrete color mapping ────────────────────────────────────────────────────
+
+test_that(".resolve_aes() maps character color column to per-obs colors", {
+  df <- data.frame(group = c("A", "B", "A"), stringsAsFactors = FALSE)
+  a  <- aes(color = group)
+  result <- .resolve(df, a, NULL, n = 3, default_color = "grey")
+  expect_length(result$color, 3L)
+  # Observations with the same level get the same color
+  expect_equal(result$color[1], result$color[3])
+  # Different levels get different colors
+  expect_false(result$color[1] == result$color[2])
+})
+
+test_that(".resolve_aes() maps factor color column correctly", {
+  df <- data.frame(group = factor(c("X", "Y", "X"), levels = c("X", "Y")))
+  a  <- aes(color = group)
+  result <- .resolve(df, a, NULL, n = 3, default_color = "grey")
+  expect_equal(result$color[1], result$color[3])  # both "X"
+  expect_false(result$color[1] == result$color[2])
+})
+
+test_that(".resolve_aes() uses named values from SeqScaleDiscrete", {
+  df  <- data.frame(cat = c("A", "B", "A"), stringsAsFactors = FALSE)
+  a   <- aes(color = cat)
+  sc  <- seq_scale_color_discrete(values = c(A = "#FF0000", B = "#0000FF"))
+  result <- .resolve(df, a, sc, n = 3, default_color = "grey")
+  expect_equal(result$color[1], "#FF0000")  # A
+  expect_equal(result$color[2], "#0000FF")  # B
+  expect_equal(result$color[3], "#FF0000")  # A again
+})
+
+test_that(".resolve_aes() uses palette function from SeqScaleDiscrete", {
+  df   <- data.frame(cat = c("P", "Q"), stringsAsFactors = FALSE)
+  a    <- aes(color = cat)
+  pal  <- function(n) c("#111111", "#222222")[seq_len(n)]
+  sc   <- seq_scale_color_discrete(palette = pal)
+  result <- .resolve(df, a, sc, n = 2, default_color = "grey")
+  expect_equal(result$color[1], "#111111")
+  expect_equal(result$color[2], "#222222")
+})
+
+test_that(".resolve_aes() applies na_value for unmatched discrete levels", {
+  df  <- data.frame(cat = c("A", NA_character_), stringsAsFactors = FALSE)
+  a   <- aes(color = cat)
+  sc  <- seq_scale_color_discrete(values = c(A = "#FF0000"), na_value = "#CCCCCC")
+  result <- .resolve(df, a, sc, n = 2, default_color = "grey")
+  expect_equal(result$color[2], "#CCCCCC")
+})
+
+
+# ── Continuous color mapping ──────────────────────────────────────────────────
+
+test_that(".resolve_aes() maps numeric column to hex colors (viridis default)", {
+  df <- data.frame(val = c(0, 50, 100))
+  a  <- aes(color = val)
+  result <- .resolve(df, a, NULL, n = 3, default_color = "grey")
+  # All results should be valid hex colors
+  expect_match(result$color[1], "^#[0-9A-Fa-f]{6}$")
+  expect_match(result$color[2], "^#[0-9A-Fa-f]{6}$")
+  expect_match(result$color[3], "^#[0-9A-Fa-f]{6}$")
+  # Extremes should differ
+  expect_false(result$color[1] == result$color[3])
+})
+
+test_that(".resolve_aes() viridis min value matches first stop", {
+  df <- data.frame(val = c(0, 100))
+  a  <- aes(color = val)
+  sc <- seq_scale_color_continuous(palette = "viridis", limits = c(0, 100))
+  result <- .resolve(df, a, sc, n = 2, default_color = "grey")
+  expect_equal(toupper(result$color[1]), "#440154")
+})
+
+test_that(".resolve_aes() viridis max value matches last stop", {
+  df <- data.frame(val = c(0, 100))
+  a  <- aes(color = val)
+  sc <- seq_scale_color_continuous(palette = "viridis", limits = c(0, 100))
+  result <- .resolve(df, a, sc, n = 2, default_color = "grey")
+  expect_equal(toupper(result$color[2]), "#FDE725")
+})
+
+test_that(".resolve_aes() uses custom limits to clamp mapping", {
+  df <- data.frame(val = c(-10, 0, 200))
+  a  <- aes(color = val)
+  sc <- seq_scale_color_continuous(palette = "viridis", limits = c(0, 100))
+  result <- .resolve(df, a, sc, n = 3, default_color = "grey")
+  # -10 clamped to 0 → same color as 0
+  expect_equal(result$color[1], result$color[2])
+  # 200 clamped to 100 → same color as the full-range max
+  sc2    <- seq_scale_color_continuous(palette = "viridis", limits = c(0, 100))
+  ref    <- .resolve(data.frame(val = 100), aes(color = val), sc2, n = 1, "grey")
+  expect_equal(result$color[3], ref$color[1])
+})
+
+test_that(".resolve_aes() applies na_value for NA continuous entries", {
+  df <- data.frame(val = c(0, NA, 100))
+  a  <- aes(color = val)
+  sc <- seq_scale_color_continuous(na_value = "#AABBCC")
+  result <- .resolve(df, a, sc, n = 3, default_color = "grey")
+  expect_equal(result$color[2], "#AABBCC")
+})
+
+
+# ── Fill mapping ──────────────────────────────────────────────────────────────
+
+test_that(".resolve_aes() resolves fill separately from color", {
+  df <- data.frame(grp = c("X", "Y"), val = c(0.0, 1.0),
+                   stringsAsFactors = FALSE)
+  a  <- aes(color = grp, fill = val)
+  sc <- seq_scale_fill_continuous(palette = "plasma", limits = c(0, 1))
+  result <- .resolve(df, a, sc, n = 2, default_color = "grey")
+  # fill should be resolved
+  expect_match(result$fill[1], "^#[0-9A-Fa-f]{6}$")
+  # color was discrete and also resolved
+  expect_false(result$color[1] == result$color[2])
+})
+
+
+# ── Passthrough aesthetics (size, alpha, shape) ───────────────────────────────
+
+test_that(".resolve_aes() passes numeric column through for 'size'", {
+  df <- data.frame(sz = c(1.0, 2.5, 0.5))
+  a  <- aes(size = sz)
+  result <- .resolve(df, a, NULL, n = 3, default_color = "grey")
+  expect_equal(result$size, c(1.0, 2.5, 0.5))
+})
+
+test_that(".resolve_aes() passes numeric column through for 'alpha'", {
+  df <- data.frame(alpha_col = c(0.2, 0.8, 1.0))
+  a  <- aes(alpha = alpha_col)
+  result <- .resolve(df, a, NULL, n = 3, default_color = "grey")
+  expect_equal(result$alpha, c(0.2, 0.8, 1.0))
+})
+
+test_that(".resolve_aes() only resolves aesthetics present in aes()", {
+  df     <- data.frame(val = 1:3)
+  a      <- aes(color = val)
+  result <- .resolve(df, a, NULL, n = 3, default_color = "grey")
+  # 'fill', 'alpha', 'size', 'shape' should not be added
+  expect_null(result$fill)
+  expect_null(result$size)
+  expect_null(result$alpha)
+  expect_null(result$shape)
+})

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -1,0 +1,141 @@
+# ── Color scales ──────────────────────────────────────────────────────────────
+
+test_that("seq_scale_color_continuous() returns correct class", {
+  s <- seq_scale_color_continuous()
+  expect_s3_class(s, "SeqScaleContinuous")
+  expect_s3_class(s, "SeqScale")
+})
+
+test_that("seq_scale_color_continuous() defaults are correct", {
+  s <- seq_scale_color_continuous()
+  expect_equal(s$aesthetic, "color")
+  expect_equal(s$type, "continuous")
+  expect_equal(s$palette, "viridis")
+  expect_null(s$limits)
+  expect_equal(s$na_value, "grey80")
+})
+
+test_that("seq_scale_color_continuous() accepts custom palette and limits", {
+  s <- seq_scale_color_continuous(palette = "plasma", limits = c(0, 100), na_value = "#FF0000")
+  expect_equal(s$palette, "plasma")
+  expect_equal(s$limits, c(0, 100))
+  expect_equal(s$na_value, "#FF0000")
+})
+
+test_that("seq_scale_color_discrete() returns correct class", {
+  s <- seq_scale_color_discrete()
+  expect_s3_class(s, "SeqScaleDiscrete")
+  expect_s3_class(s, "SeqScale")
+})
+
+test_that("seq_scale_color_discrete() defaults are correct", {
+  s <- seq_scale_color_discrete()
+  expect_equal(s$aesthetic, "color")
+  expect_equal(s$type, "discrete")
+  expect_null(s$values)
+  expect_null(s$palette)
+  expect_equal(s$na_value, "grey80")
+})
+
+test_that("seq_scale_color_discrete() stores named color values", {
+  vals <- c(TypeA = "#FF0000", TypeB = "#0000FF")
+  s <- seq_scale_color_discrete(values = vals)
+  expect_equal(s$values, vals)
+})
+
+test_that("seq_scale_color_discrete() stores a palette function", {
+  pal_fn <- function(n) grDevices::rainbow(n)
+  s <- seq_scale_color_discrete(palette = pal_fn)
+  expect_identical(s$palette, pal_fn)
+})
+
+# ── Fill scale delegation ─────────────────────────────────────────────────────
+
+test_that("seq_scale_fill_continuous() sets aesthetic to 'fill'", {
+  s <- seq_scale_fill_continuous()
+  expect_equal(s$aesthetic, "fill")
+  expect_s3_class(s, "SeqScaleContinuous")
+})
+
+test_that("seq_scale_fill_continuous() passes through all other args", {
+  s <- seq_scale_fill_continuous(palette = "magma", limits = c(-1, 1))
+  expect_equal(s$palette, "magma")
+  expect_equal(s$limits, c(-1, 1))
+})
+
+test_that("seq_scale_fill_discrete() sets aesthetic to 'fill'", {
+  s <- seq_scale_fill_discrete()
+  expect_equal(s$aesthetic, "fill")
+  expect_s3_class(s, "SeqScaleDiscrete")
+})
+
+test_that("seq_scale_fill_discrete() passes through values", {
+  vals <- c(A = "red", B = "blue")
+  s <- seq_scale_fill_discrete(values = vals)
+  expect_equal(s$values, vals)
+})
+
+# ── Position scales ───────────────────────────────────────────────────────────
+
+test_that("seq_scale_genomic() requires a GRanges object", {
+  expect_error(seq_scale_genomic("not_granges"))
+  expect_error(seq_scale_genomic(data.frame(chr = "chr1")))
+})
+
+test_that("seq_scale_genomic() returns correct class", {
+  gr <- GenomicRanges::GRanges("chr1:1-1000000")
+  s <- seq_scale_genomic(gr)
+  expect_s3_class(s, "SeqScaleGenomic")
+  expect_s3_class(s, "SeqPositionScale")
+})
+
+test_that("seq_scale_genomic() stores windows and defaults scale_factor to 1e-6", {
+  gr <- GenomicRanges::GRanges("chr1:1-1000000")
+  s <- seq_scale_genomic(gr)
+  expect_identical(s$windows, gr)
+  expect_equal(s$type, "genomic")
+  expect_equal(s$scale_factor, 1e-6)
+})
+
+test_that("seq_scale_genomic() reads scale_factor from mcols$scale", {
+  gr <- GenomicRanges::GRanges("chr1:1-1000000")
+  S4Vectors::mcols(gr)$scale <- 1e-3
+  s <- seq_scale_genomic(gr)
+  expect_equal(s$scale_factor, 1e-3)
+})
+
+test_that("seq_scale_genomic() accepts explicit scale_factor override", {
+  gr <- GenomicRanges::GRanges("chr1:1-1000000")
+  s <- seq_scale_genomic(gr, scale_factor = 1)
+  expect_equal(s$scale_factor, 1)
+})
+
+test_that("seq_scale_continuous() returns correct class and defaults", {
+  s <- seq_scale_continuous()
+  expect_s3_class(s, "SeqScaleContinuous_Pos")
+  expect_s3_class(s, "SeqPositionScale")
+  expect_equal(s$type, "continuous")
+  expect_null(s$limits)
+  expect_equal(s$n_breaks, 5)
+})
+
+test_that("seq_scale_continuous() accepts limits and n_breaks", {
+  s <- seq_scale_continuous(limits = c(0, 1), n_breaks = 10)
+  expect_equal(s$limits, c(0, 1))
+  expect_equal(s$n_breaks, 10)
+})
+
+test_that("seq_scale_discrete() returns correct class and defaults", {
+  s <- seq_scale_discrete()
+  expect_s3_class(s, "SeqScaleDiscrete_Pos")
+  expect_s3_class(s, "SeqPositionScale")
+  expect_equal(s$type, "discrete")
+  expect_null(s$levels)
+  expect_null(s$labels)
+})
+
+test_that("seq_scale_discrete() stores levels and labels", {
+  s <- seq_scale_discrete(levels = c("T_cell", "B_cell"), labels = c("T", "B"))
+  expect_equal(s$levels, c("T_cell", "B_cell"))
+  expect_equal(s$labels, c("T", "B"))
+})

--- a/tests/testthat/test-seq-elements.R
+++ b/tests/testthat/test-seq-elements.R
@@ -1,0 +1,244 @@
+# Helpers ─────────────────────────────────────────────────────────────────────
+
+# Three ranges spanning chr1, annotated with cell_type, mutation_count, and
+# a pre-existing 'color' column for legacy-path tests.
+.tile_gr <- function() {
+  GenomicRanges::GRanges(
+    c("chr1:1-100", "chr1:101-200", "chr1:201-300"),
+    cell_type      = c("T_cell", "B_cell", "T_cell"),
+    mutation_count = c(0L, 50L, 100L),
+    color          = c("#FF0000", "#00FF00", "#FF0000")
+  )
+}
+
+.point_gr <- function() {
+  GenomicRanges::GRanges(
+    c("chr1:1-100", "chr1:101-200", "chr1:201-300"),
+    score = c(1.0, 2.0, 3.0),
+    group = c("A", "B", "A")
+  )
+}
+
+
+# ── Constructor wrappers ──────────────────────────────────────────────────────
+
+test_that("SeqPlot() wrapper creates an R6 SeqPlot object", {
+  plt <- SeqPlot()
+  expect_true(inherits(plt, "SeqPlot"))
+  expect_true(R6::is.R6(plt))
+})
+
+test_that("SeqTrack() wrapper creates an R6 SeqTrack object", {
+  trk <- SeqTrack()
+  expect_true(inherits(trk, "SeqTrack"))
+  expect_true(R6::is.R6(trk))
+})
+
+test_that("SeqPoint() wrapper creates an R6 SeqPoint object", {
+  gr  <- .point_gr()
+  pt  <- SeqPoint(gr, yCol = "score")
+  expect_true(inherits(pt, "SeqPoint"))
+  expect_true(R6::is.R6(pt))
+})
+
+test_that("SeqLine() wrapper creates an R6 SeqLine object", {
+  gr  <- .point_gr()
+  ln  <- SeqLine(gr, yCol = "score")
+  expect_true(inherits(ln, "SeqLine"))
+})
+
+test_that("SeqBar() wrapper creates an R6 SeqBar object", {
+  gr  <- .point_gr()
+  br  <- SeqBar(gr, yCol = "score")
+  expect_true(inherits(br, "SeqBar"))
+})
+
+
+# ── SeqTile: new aes(y = ...) path ───────────────────────────────────────────
+
+test_that("SeqTile aes(y=) stores groups in order of first appearance", {
+  tile <- SeqTile(.tile_gr(), aes = aes(y = cell_type))
+  expect_equal(tile$groups, c("T_cell", "B_cell"))
+})
+
+test_that("SeqTile aes(y=) computes y index mapping correctly", {
+  tile <- SeqTile(.tile_gr(), aes = aes(y = cell_type))
+  # T_cell=1, B_cell=2, T_cell=1
+  expect_equal(tile$y, c(1L, 2L, 1L))
+})
+
+test_that("SeqTile aes(y=) sets groupCol to the mapped column name", {
+  tile <- SeqTile(.tile_gr(), aes = aes(y = cell_type))
+  expect_equal(tile$groupCol, "cell_type")
+})
+
+test_that("SeqTile aes(y=) with a factor preserves factor levels", {
+  gr <- .tile_gr()
+  GenomicRanges::mcols(gr)$cell_type <- factor(
+    GenomicRanges::mcols(gr)$cell_type,
+    levels = c("B_cell", "T_cell")
+  )
+  tile <- SeqTile(gr, aes = aes(y = cell_type))
+  expect_equal(tile$groups, c("B_cell", "T_cell"))  # factor order respected
+})
+
+test_that("SeqTile aes(y=) errors when mapped column is absent", {
+  gr <- .tile_gr()
+  expect_error(
+    SeqTile(gr, aes = aes(y = nonexistent_col)),
+    "not found"
+  )
+})
+
+test_that("SeqTile aes(fill=) resolves continuous fill into mcols$color", {
+  scale <- seq_scale_fill_continuous(palette = "viridis",
+                                     limits  = c(0, 100))
+  tile  <- SeqTile(.tile_gr(),
+                   aes   = aes(y = cell_type, fill = mutation_count),
+                   scale = scale)
+  colors <- as.character(GenomicRanges::mcols(tile$gr)$color)
+  expect_length(colors, 3L)
+  expect_match(colors[1], "^#[0-9A-Fa-f]{6}$")
+  # Observation at count=0 and count=100 should have different colors
+  expect_false(colors[1] == colors[3])
+})
+
+test_that("SeqTile aes(fill=) viridis min/max colors are correct", {
+  gr    <- GenomicRanges::GRanges(
+    c("chr1:1-100", "chr1:101-200"),
+    cell  = c("A", "B"),
+    val   = c(0L, 100L)
+  )
+  scale <- seq_scale_fill_continuous(palette = "viridis", limits = c(0, 100))
+  tile  <- SeqTile(gr, aes = aes(y = cell, fill = val), scale = scale)
+  colors <- as.character(GenomicRanges::mcols(tile$gr)$color)
+  expect_equal(toupper(colors[1]), "#440154")  # viridis low
+  expect_equal(toupper(colors[2]), "#FDE725")  # viridis high
+})
+
+test_that("SeqTile aes(fill=) discrete fill uses SeqScaleDiscrete colors", {
+  scale <- seq_scale_fill_discrete(values = c(T_cell = "#AA0000",
+                                               B_cell = "#0000AA"))
+  tile  <- SeqTile(.tile_gr(),
+                   aes   = aes(y = cell_type, fill = cell_type),
+                   scale = scale)
+  colors <- as.character(GenomicRanges::mcols(tile$gr)$color)
+  expect_equal(colors[1], "#AA0000")  # T_cell
+  expect_equal(colors[2], "#0000AA")  # B_cell
+  expect_equal(colors[3], "#AA0000")  # T_cell again
+})
+
+test_that("SeqTile .infer_scale_y() returns a SeqScaleDiscrete_Pos when groups are set", {
+  tile <- SeqTile(.tile_gr(), aes = aes(y = cell_type))
+  scale <- tile$.infer_scale_y()
+  expect_s3_class(scale, "SeqScaleDiscrete_Pos")
+  expect_equal(scale$levels, tile$groups)
+})
+
+test_that("SeqTile .infer_scale_y() returns NULL when no grouping is set", {
+  # A tile with only a color column, no y mapping
+  gr   <- .tile_gr()
+  tile <- SeqTile(gr)
+  expect_null(tile$.infer_scale_y())
+})
+
+
+# ── SeqTile: legacy groupCol path ────────────────────────────────────────────
+
+test_that("SeqTile groupCol (legacy) sets groups and y correctly", {
+  tile <- SeqTile(.tile_gr(), groupCol = "cell_type")
+  expect_equal(tile$groups, c("T_cell", "B_cell"))
+  expect_equal(tile$y, c(1L, 2L, 1L))
+})
+
+test_that("SeqTile groupCol (legacy) errors when column is absent", {
+  gr <- .tile_gr()
+  expect_error(SeqTile(gr, groupCol = "no_such_col"), "not found")
+})
+
+test_that("SeqTile without color column and without aes(fill=) errors", {
+  gr <- GenomicRanges::GRanges(
+    c("chr1:1-100"),
+    cell_type = "T_cell"
+  )
+  # No 'color' mcol and no fill aes → should error
+  expect_error(SeqTile(gr, groupCol = "cell_type"))
+})
+
+
+# ── SeqPoint: aes + scale ────────────────────────────────────────────────────
+
+test_that("SeqPoint with aes(color=) resolves discrete colors", {
+  gr  <- .point_gr()
+  sc  <- seq_scale_color_discrete(values = c(A = "#FF0000", B = "#0000FF"))
+  pt  <- SeqPoint(gr, yCol = "score", aes = aes(color = group), scale = sc)
+  # Obs 1 = A, 2 = B, 3 = A
+  expect_equal(pt$aesthetics$color[1], "#FF0000")
+  expect_equal(pt$aesthetics$color[2], "#0000FF")
+  expect_equal(pt$aesthetics$color[3], "#FF0000")
+})
+
+test_that("SeqPoint with aes(color=) resolves continuous colors", {
+  gr  <- .point_gr()
+  sc  <- seq_scale_color_continuous(palette = "viridis",
+                                    limits  = c(1, 3))
+  pt  <- SeqPoint(gr, yCol = "score", aes = aes(color = score), scale = sc)
+  colors <- pt$aesthetics$color
+  expect_length(colors, 3L)
+  expect_match(colors[1], "^#[0-9A-Fa-f]{6}$")
+  # score=1 (min) and score=3 (max) should differ
+  expect_false(colors[1] == colors[3])
+})
+
+test_that("SeqPoint without aes uses fixed color from aesthetics", {
+  gr <- .point_gr()
+  pt <- SeqPoint(gr, yCol = "score", color = "#123456")
+  expect_true(all(pt$aesthetics$color == "#123456"))
+})
+
+
+# ── SeqSegment: aes + scale ──────────────────────────────────────────────────
+
+test_that("SeqSegment with aes(color=) resolves colors", {
+  gr <- GenomicRanges::GRanges(
+    c("chr1:1-100", "chr1:200-300"),
+    y0   = c(0.0, 0.5),
+    y1   = c(0.4, 0.9),
+    grp  = c("up", "down")
+  )
+  sc  <- seq_scale_color_discrete(values = c(up = "#00CC00", down = "#CC0000"))
+  seg <- SeqSegment(gr, y0Col = "y0", y1Col = "y1",
+                    aes = aes(color = grp), scale = sc)
+  expect_equal(seg$aesthetics$color[1], "#00CC00")
+  expect_equal(seg$aesthetics$color[2], "#CC0000")
+})
+
+
+# ── SeqBar: aes + scale ──────────────────────────────────────────────────────
+
+test_that("SeqBar with aes(fill=) resolves fill", {
+  gr <- GenomicRanges::GRanges(
+    c("chr1:1-100", "chr1:101-200"),
+    height = c(10.0, 20.0),
+    grp    = c("A", "B")
+  )
+  sc <- seq_scale_fill_discrete(values = c(A = "#AAAA00", B = "#0000AA"))
+  br <- SeqBar(gr, yCol = "height", aes = aes(fill = grp), scale = sc)
+  expect_equal(br$aesthetics$fill[1], "#AAAA00")
+  expect_equal(br$aesthetics$fill[2], "#0000AA")
+})
+
+
+# ── SeqLine: aes + scale ─────────────────────────────────────────────────────
+
+test_that("SeqLine with aes(color=) resolves color", {
+  gr <- GenomicRanges::GRanges(
+    c("chr1:1-100", "chr1:101-200", "chr1:201-300"),
+    val  = c(1.0, 5.0, 10.0),
+    grp  = c("X", "X", "X")
+  )
+  sc <- seq_scale_color_continuous(palette = "plasma", limits = c(1, 10))
+  ln <- SeqLine(gr, yCol = "val", aes = aes(color = val), scale = sc)
+  expect_length(ln$aesthetics$color, 3L)
+  expect_match(ln$aesthetics$color[1], "^#[0-9A-Fa-f]{6}$")
+})


### PR DESCRIPTION
- Add testthat to DESCRIPTION Suggests
- tests/testthat.R: standard test runner
- test-aes.R: aes() NSE function (8 tests)
- test-scales.R: color and position scale constructors (20 tests)
- test-operators.R: %|% and %+% operator pipeline (12 tests)
- test-resolve-aes.R: internal .resolve_aes() resolver (15 tests)
- test-seq-elements.R: SeqTile/SeqPoint/etc. with new aes= API (22 tests)